### PR TITLE
fix: bluetooth icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,16 +60,13 @@
           "type": "font",
           "name": "FONT_ICONS_18",
           "file": "fonts/Lilex/LilexNerdFontMono-Regular.ttf",
-          "characterRegex": "[󰂯]"
+          "characterRegex": "[]"
         },
         {
           "type": "font",
           "name": "FONT_ICONS_24",
           "file": "fonts/Lilex/LilexNerdFontMono-Regular.ttf",
-          "targetPlatforms": [
-            "emery"
-          ],
-          "characterRegex": "[󰂯]"
+          "characterRegex": "[]"
         },
         {
           "type": "font",
@@ -81,9 +78,6 @@
           "type": "font",
           "name": "FONT_ICONS_38",
           "file": "fonts/Lilex/LilexNerdFontMono-Regular.ttf",
-          "targetPlatforms": [
-            "emery"
-          ],
           "characterRegex": "[ ]"
         },
         {
@@ -96,9 +90,6 @@
           "type": "font",
           "name": "FONT_ICONS_49",
           "file": "fonts/Lilex/LilexNerdFontMono-Regular.ttf",
-          "targetPlatforms": [
-            "emery"
-          ],
           "characterRegex": "[]"
         },
         {
@@ -126,9 +117,6 @@
           "type": "font",
           "name": "FONT_TERMINUS_MONO_15",
           "file": "fonts/Terminus/TerminessNerdFontMono-Bold.ttf",
-          "targetPlatforms": [
-            "emery"
-          ],
           "characterRegex": "[AMP]"
         },
         {
@@ -139,10 +127,7 @@
         {
           "type": "font",
           "name": "FONT_TERMINUS_MONO_21",
-          "file": "fonts/Terminus/TerminessNerdFontMono-Bold.ttf",
-          "targetPlatforms": [
-            "emery"
-          ]
+          "file": "fonts/Terminus/TerminessNerdFontMono-Bold.ttf"
         },
         {
           "type": "font",
@@ -154,9 +139,6 @@
           "type": "font",
           "name": "FONT_TERMINUS_MONO_33",
           "file": "fonts/Terminus/TerminessNerdFontMono-Bold.ttf",
-          "targetPlatforms": [
-            "emery"
-          ],
           "characterRegex": "[0-9°\\-]"
         },
         {

--- a/src/c/font.c
+++ b/src/c/font.c
@@ -19,7 +19,7 @@ const char *ICON_BATTERY_100 = "";
 const char *ICON_STEPS = "";
 const char *ICON_HEART_RATE = "";
 const char *ICON_UTC = "";
-const char *ICON_BLUETOOTH_CONNECTED = "󰂯";
+const char *ICON_BLUETOOTH_CONNECTED = "";
 const char *ICON_SUNRISE = "";
 const char *ICON_SUNSET = "";
 


### PR DESCRIPTION
We use nerd font icons. There are a few bluetooth icons and for some reason the one we were using is not dislaying anymore on a Pabble Time
2. It still works in the emulator for some reason.

󰂯 - Old icon
 - New icon